### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,11 @@
-FROM ubuntu:latest
+FROM mcr.microsoft.com/dotnet/core/runtime-deps:5.0
 
-RUN apt update && DEBIAN_FRONTEND="noninteractive" apt install -y libicu66 unzip wget
+ADD https://github.com/Manager-io/Manager.zip/releases/latest/download/ManagerServer-Linux-x64.tar.gz /tmp/manager-server.tar.gz
 
-RUN if [ "$TZ" != "" ]; then ln -fs /usr/share/zoneinfo/$TZ /etc/localtime && dpkg-reconfigure --frontend noninteractive tzdata; fi
-
-RUN mkdir /opt/manager-server
-RUN wget -q https://github.com/Manager-io/Manager.zip/releases/download/20.10.44/ManagerServer-Linux-x64.zip
-RUN unzip ManagerServer-Linux-x64.zip -d /opt/manager-server/
-RUN rm -f ManagerServer-Linux-x64.zip
-RUN chmod +x /opt/manager-server/ManagerServer
+RUN mkdir /opt/manager-server; \
+    tar -C /opt/manager-server/ -xzvf /tmp/manager-server.tar.gz; \
+    rm -f /tmp/manager-server.tar.gz; \
+    chmod +x /opt/manager-server/ManagerServer
 
 # Run instance of Manager
 CMD ["/opt/manager-server/ManagerServer","-port","8080","-path","/data"]


### PR DESCRIPTION
This is docker file I'm using to host cloud edition.

The latest version of Manager (20.10.45) is compiled with .NET 5.0 and I'm changing `zip` to `tar.gz` for Linux. This avoids installing unzip on Linux.

As a result, I'd use `mcr.microsoft.com/dotnet/core/runtime-deps:5.0` instead of `ubuntu:latest`

This will make Manager Server aware it runs within docker container (it will work better if RAM is constrained) and the overall image size will be smaller. It's basically `amd64/debian:buster-slim` with a few dependencies.

Also, in my docker file, I'm simply referencing the latest version of `ManagerServer-Linux-x64.tar.gz`. See URL.

With the timezone in your docker file, I think that is clever however in future versions of Manager, the program will rely on client timezone via javascript and will not use server local time for anything.